### PR TITLE
Added gulp-eslint missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/taylor1791/few-eslint#readme",
   "dependencies": {
+    "gulp-eslint": "^1.0.0",
     "ramda": "^0.17.1"
   }
 }


### PR DESCRIPTION
Trying to fix:
[12:14:34] Error: Cannot find module 'gulp-eslint'

when I run "gulp manticore-sting"
